### PR TITLE
moved asset_contents

### DIFF
--- a/Paint layouts/Page layout/Header-with-box.html
+++ b/Paint layouts/Page layout/Header-with-box.html
@@ -37,10 +37,8 @@ class="with-box" style="background-image: url(%asset_metadata_BANNER.Image^as_as
   %else_asset_metadata_CONTENT.LandingPageShort% 
   %end_asset_metadata_CONTENT.LandingPageShort% 
 
-  %asset_contents%
-
 %end_tabbed_nav%
 
-
+ %asset_contents%
       
 %end_asset_metadata_DESIGN.PageTemplate^contains:template-header-box%

--- a/Paint layouts/Page layout/header-image-bottom.html
+++ b/Paint layouts/Page layout/header-image-bottom.html
@@ -37,10 +37,8 @@ class="image" style="background-image: url(%asset_metadata_BANNER.Image^as_asset
   %else_asset_metadata_CONTENT.LandingPageShort% 
   %end_asset_metadata_CONTENT.LandingPageShort% 
 
-  %asset_contents%
-
 %end_tabbed_nav%
 
-
+    %asset_contents%
       
 %end_asset_metadata_DESIGN.PageTemplate^contains:template-header-image-bottom%

--- a/Paint layouts/Page layout/header-image-dark.html
+++ b/Paint layouts/Page layout/header-image-dark.html
@@ -1,10 +1,10 @@
-%begin_asset_metadata_DESIGN.PageTemplate^contains:template-landingpage%
+%begin_asset_metadata_DESIGN.PageTemplate^contains:template-header-image-dark%
         
 <!-- Begin background image header -->
 <header %begin_enable_banner_image% 
 class="image" style="background-image: url(%asset_metadata_BANNER.Image^as_asset:asset_url%);"
 %end_enable_banner_image%>
-	<div class="mid-align">
+	<div class="mid-align blurred">
      
   	%begin_asset_metadata_HEADER.HeaderText% 
         <h1>%asset_metadata_HEADER.HeaderText%</h1>     
@@ -42,4 +42,4 @@ class="image" style="background-image: url(%asset_metadata_BANNER.Image^as_asset
 
     %asset_contents%
       
-%end_asset_metadata_DESIGN.PageTemplate^contains:template-landingpage%
+%end_asset_metadata_DESIGN.PageTemplate^contains:template-header-image-dark%

--- a/Paint layouts/Page layout/inside-page-with-blue-header.html
+++ b/Paint layouts/Page layout/inside-page-with-blue-header.html
@@ -25,8 +25,8 @@
     </section>
   %end_add_content% 
 
-  %asset_contents%
-
 %end_tabbed_nav%
+
+    %asset_contents%
 
 %end_asset_metadata_DESIGN.PageTemplate^contains:template-standard-page-blue-header%


### PR DESCRIPTION
moved asset_contents keyword on header with image and blue header.

This allows you to add content to the parent page when tabs are set
i.e. enquiry or contact info