### PR TITLE
css overides to checklist example

### DIFF
--- a/Container templates/Checklist/Checklist-Frontent-Layout.html
+++ b/Container templates/Checklist/Checklist-Frontent-Layout.html
@@ -1,0 +1,263 @@
+<!-- MCE: Check List content template version %globals_asset_version:1891853% -->
+<div class="ct-checklist"> 
+<form>
+<fieldset><ul class="checklist">
+  %begin_asset_metadata_content^explode:; ^index:0%
+    %begin_asset_metadata_CheckFirstItem^:eq:Yes:%
+    <li class="on"><input checked="checked" class="checkbox" id="c0" type="checkbox" /><label for="c0"><span>
+      %asset_metadata_content^explode:; ^index:0^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+    %else_asset_metadata_CheckFirstItem^:eq:Yes:%
+    <li><input class="checkbox" id="c0" type="checkbox" /><label for="c0"><span>
+      %asset_metadata_content^explode:; ^index:0^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+    %end_asset_metadata_CheckFirstItem^:eq:Yes:%
+  %end_asset_metadata_content^explode:; ^index:0%
+  %begin_asset_metadata_content^explode:; ^index:1%
+    <li><input class="checkbox" id="c1" type="checkbox" /><label for="c1"><span>
+      %asset_metadata_content^explode:; ^index:1^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:1%
+  %begin_asset_metadata_content^explode:; ^index:2%
+    <li><input class="checkbox" id="c2" type="checkbox" /><label for="c2"><span>
+      %asset_metadata_content^explode:; ^index:2^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:2%
+  %begin_asset_metadata_content^explode:; ^index:3%
+    <li><input class="checkbox" id="c3" type="checkbox" /><label for="c3"><span>
+      %asset_metadata_content^explode:; ^index:3^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:3%
+  %begin_asset_metadata_content^explode:; ^index:4%
+    <li><input class="checkbox" id="c4" type="checkbox" /><label for="c4"><span>
+      %asset_metadata_content^explode:; ^index:4^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:4%
+  %begin_asset_metadata_content^explode:; ^index:5%
+    <li><input class="checkbox" id="c5" type="checkbox" /><label for="c5"><span>
+      %asset_metadata_content^explode:; ^index:5^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:5%
+  %begin_asset_metadata_content^explode:; ^index:6%
+    <li><input class="checkbox" id="c6" type="checkbox" /><label for="c6"><span>
+      %asset_metadata_content^explode:; ^index:6^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:6%
+  %begin_asset_metadata_content^explode:; ^index:7%
+    <li><input class="checkbox" id="c7" type="checkbox" /><label for="c7"><span>
+      %asset_metadata_content^explode:; ^index:7^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:7%
+  %begin_asset_metadata_content^explode:; ^index:8%
+    <li><input class="checkbox" id="c8" type="checkbox" /><label for="c8"><span>
+      %asset_metadata_content^explode:; ^index:8^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:8%
+  %begin_asset_metadata_content^explode:; ^index:9%
+    <li><input class="checkbox" id="c9" type="checkbox" /><label for="c9"><span>
+      %asset_metadata_content^explode:; ^index:9^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:9%
+  %begin_asset_metadata_content^explode:; ^index:10%
+    <li><input class="checkbox" id="c10" type="checkbox" /><label for="c10"><span>
+      %asset_metadata_content^explode:; ^index:10^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:10%
+  %begin_asset_metadata_content^explode:; ^index:11%
+    <li><input class="checkbox" id="c11" type="checkbox" /><label for="c11"><span>
+      %asset_metadata_content^explode:; ^index:11^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:11%
+  %begin_asset_metadata_content^explode:; ^index:12%
+    <li><input class="checkbox" id="c12" type="checkbox" /><label for="c12"><span>
+      %asset_metadata_content^explode:; ^index:12^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:12%
+  %begin_asset_metadata_content^explode:; ^index:13%
+    <li><input class="checkbox" id="c13" type="checkbox" /><label for="c13"><span>
+      %asset_metadata_content^explode:; ^index:13^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:13%
+  %begin_asset_metadata_content^explode:; ^index:14%
+    <li><input class="checkbox" id="c14" type="checkbox" /><label for="c14"><span>
+      %asset_metadata_content^explode:; ^index:14^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:14%
+  %begin_asset_metadata_content^explode:; ^index:15%
+    <li><input class="checkbox" id="c15" type="checkbox" /><label for="c15"><span>
+      %asset_metadata_content^explode:; ^index:15^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:15%
+  %begin_asset_metadata_content^explode:; ^index:16%
+    <li><input class="checkbox" id="c16" type="checkbox" /><label for="c16"><span>
+      %asset_metadata_content^explode:; ^index:16^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:16%
+  %begin_asset_metadata_content^explode:; ^index:17%
+    <li><input class="checkbox" id="c17" type="checkbox" /><label for="c17"><span>
+      %asset_metadata_content^explode:; ^index:17^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:17%
+  %begin_asset_metadata_content^explode:; ^index:18%
+    <li><input class="checkbox" id="c18" type="checkbox" /><label for="c18"><span>
+      %asset_metadata_content^explode:; ^index:18^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:18%
+  %begin_asset_metadata_content^explode:; ^index:19%
+    <li><input class="checkbox" id="c19" type="checkbox" /><label for="c19"><span>
+      %asset_metadata_content^explode:; ^index:19^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:19%
+  %begin_asset_metadata_content^explode:; ^index:20%
+    <li><input class="checkbox" id="c20" type="checkbox" /><label for="c20"><span>
+      %asset_metadata_content^explode:; ^index:20^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:20%
+  %begin_asset_metadata_content^explode:; ^index:21%
+    <li><input class="checkbox" id="c21" type="checkbox" /><label for="c21"><span>
+      %asset_metadata_content^explode:; ^index:21^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:21%
+  %begin_asset_metadata_content^explode:; ^index:22%
+    <li><input class="checkbox" id="c22" type="checkbox" /><label for="c22"><span>
+      %asset_metadata_content^explode:; ^index:22^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:22%
+  %begin_asset_metadata_content^explode:; ^index:23%
+    <li><input class="checkbox" id="c23" type="checkbox" /><label for="c23"><span>
+      %asset_metadata_content^explode:; ^index:23^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:23%
+  %begin_asset_metadata_content^explode:; ^index:24%
+    <li><input class="checkbox" id="c24" type="checkbox" /><label for="c24"><span>
+      %asset_metadata_content^explode:; ^index:24^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:24%
+  %begin_asset_metadata_content^explode:; ^index:25%
+    <li><input class="checkbox" id="c25" type="checkbox" /><label for="c25"><span>
+      %asset_metadata_content^explode:; ^index:25^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:25%
+  %begin_asset_metadata_content^explode:; ^index:26%
+    <li><input class="checkbox" id="c26" type="checkbox" /><label for="c26"><span>
+      %asset_metadata_content^explode:; ^index:26^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:26%
+  %begin_asset_metadata_content^explode:; ^index:27%
+    <li><input class="checkbox" id="c27" type="checkbox" /><label for="c27"><span>
+      %asset_metadata_content^explode:; ^index:27^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:27%
+  %begin_asset_metadata_content^explode:; ^index:28%
+    <li><input class="checkbox" id="c28" type="checkbox" /><label for="c28"><span>
+      %asset_metadata_content^explode:; ^index:28^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:28%
+  %begin_asset_metadata_content^explode:; ^index:29%
+    <li><input class="checkbox" id="c29" type="checkbox" /><label for="c29"><span>
+      %asset_metadata_content^explode:; ^index:29^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:29%
+  %begin_asset_metadata_content^explode:; ^index:30%
+    <li><input class="checkbox" id="c30" type="checkbox" /><label for="c30"><span>
+      %asset_metadata_content^explode:; ^index:30^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:30%
+  %begin_asset_metadata_content^explode:; ^index:31%
+    <li><input class="checkbox" id="c31" type="checkbox" /><label for="c31"><span>
+      %asset_metadata_content^explode:; ^index:31^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:31%
+  %begin_asset_metadata_content^explode:; ^index:32%
+    <li><input class="checkbox" id="c32" type="checkbox" /><label for="c32"><span>
+      %asset_metadata_content^explode:; ^index:32^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:32%
+  %begin_asset_metadata_content^explode:; ^index:33%
+    <li><input class="checkbox" id="c33" type="checkbox" /><label for="c33"><span>
+      %asset_metadata_content^explode:; ^index:33^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:33%
+  %begin_asset_metadata_content^explode:; ^index:34%
+    <li><input class="checkbox" id="c34" type="checkbox" /><label for="c34"><span>
+      %asset_metadata_content^explode:; ^index:34^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:34%
+  %begin_asset_metadata_content^explode:; ^index:35%
+    <li><input class="checkbox" id="c35" type="checkbox" /><label for="c35"><span>
+      %asset_metadata_content^explode:; ^index:35^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:35%
+  %begin_asset_metadata_content^explode:; ^index:36%
+    <li><input class="checkbox" id="c36" type="checkbox" /><label for="c36"><span>
+      %asset_metadata_content^explode:; ^index:36^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:36%
+  %begin_asset_metadata_content^explode:; ^index:37%
+    <li><input class="checkbox" id="c37" type="checkbox" /><label for="c37"><span>
+      %asset_metadata_content^explode:; ^index:37^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:37%
+  %begin_asset_metadata_content^explode:; ^index:38%
+    <li><input class="checkbox" id="c38" type="checkbox" /><label for="c38"><span>
+      %asset_metadata_content^explode:; ^index:38^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:38%
+  %begin_asset_metadata_content^explode:; ^index:39%
+    <li><input class="checkbox" id="c39" type="checkbox" /><label for="c39"><span>
+      %asset_metadata_content^explode:; ^index:39^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:39%
+  %begin_asset_metadata_content^explode:; ^index:40%
+    <li><input class="checkbox" id="c40" type="checkbox" /><label for="c40"><span>
+      %asset_metadata_content^explode:; ^index:40^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:40%
+  %begin_asset_metadata_content^explode:; ^index:41%
+    <li><input class="checkbox" id="c41" type="checkbox" /><label for="c41"><span>
+      %asset_metadata_content^explode:; ^index:41^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:41%
+  %begin_asset_metadata_content^explode:; ^index:42%
+    <li><input class="checkbox" id="c42" type="checkbox" /><label for="c42"><span>
+      %asset_metadata_content^explode:; ^index:42^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:42%
+  %begin_asset_metadata_content^explode:; ^index:43%
+    <li><input class="checkbox" id="c43" type="checkbox" /><label for="c43"><span>
+      %asset_metadata_content^explode:; ^index:43^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:43%
+  %begin_asset_metadata_content^explode:; ^index:44%
+    <li><input class="checkbox" id="c44" type="checkbox" /><label for="c44"><span>
+      %asset_metadata_content^explode:; ^index:44^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:44%
+  %begin_asset_metadata_content^explode:; ^index:45%
+    <li><input class="checkbox" id="c45" type="checkbox" /><label for="c45"><span>
+      %asset_metadata_content^explode:; ^index:45^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:45%
+  %begin_asset_metadata_content^explode:; ^index:46%
+    <li><input class="checkbox" id="c46" type="checkbox" /><label for="c46"><span>
+      %asset_metadata_content^explode:; ^index:46^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:46%
+  %begin_asset_metadata_content^explode:; ^index:47%
+    <li><input class="checkbox" id="c47" type="checkbox" /><label for="c47"><span>
+      %asset_metadata_content^explode:; ^index:47^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:47%
+  %begin_asset_metadata_content^explode:; ^index:48%
+    <li><input class="checkbox" id="c48" type="checkbox" /><label for="c48"><span>
+      %asset_metadata_content^explode:; ^index:48^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:48%
+  %begin_asset_metadata_content^explode:; ^index:49%
+    <li><input class="checkbox" id="c49" type="checkbox" /><label for="c49"><span>
+      %asset_metadata_content^explode:; ^index:49^replace:\x253B:;^replace:\x08:^replace:<p>: ^replace:<\/p>:<br>%</span></label>
+    </li>
+  %end_asset_metadata_content^explode:; ^index:49%
+</ul></fieldset>
+</form>
+</div>

--- a/uom-mce-1525672.css
+++ b/uom-mce-1525672.css
@@ -2,7 +2,7 @@
 Template Name: uom-mce.css
 UOM DDS Version: 5.0
 Author: External Relations Digital Team - Based on UoM Design Template
-Updated: 04/11/2016
+Updated: 16/11/2016
 */
 
 /* give some padding to the top of pages - this is a fix until release 5.3*/
@@ -23,11 +23,6 @@ Updated: 04/11/2016
 .uomcontent footer.cta ul.quicklinks li {padding: 0px;}
 .uomcontent footer.cta ul.site-links li {padding: 0px;}
 .uomcontent [role="main"] footer {padding-bottom: 0rem;}
-
-/* bug 3/11/2015 issue #420 and #419 from v3.3.1 to v3.4.1 
-   template: blue header with jump nav    
-   page: apply now */
-.uomcontent fieldset label {width: 40rem;}
 
 /* correcting issues with styles when using native Matrix form builder */
 .uomcontent legend.sq-form-section-title {
@@ -137,7 +132,7 @@ div.sq-form-captcha {
     }
 
 /* 21/10/16 unstyled form overrides for checkboxes to work */
-uomcontent#top form:not(.unstyled-controls):not(.filtered-listing-select) fieldset input[type=checkbox]:not(.unstyled),
+.uomcontent#top form:not(.unstyled-controls):not(.filtered-listing-select) fieldset input[type=checkbox]:not(.unstyled),
 .uomcontent#top form:not(.unstyled-controls):not(.filtered-listing-select) fieldset input[type=radio]:not(.unstyled) {
   position: static !important;
 }
@@ -163,9 +158,7 @@ uomcontent#top form:not(.unstyled-controls):not(.filtered-listing-select) fields
   position: static !important;
 }
 
-#top.uomcontent form:not(.unstyled-controls):not(.filtered-listing-select) fieldset ul {
-  padding-left: 0;
-}
+#top.uomcontent form:not(.unstyled-controls):not(.filtered-listing-select) fieldset ul.checklist input[type="checkbox"]:not(.unstyled) {position: absolute!important;}
 
 /* 26/07/16 online quiz overrides */
 .uomcontent .sq-online-quiz-question-multichoice ul {padding-left: 0px;}


### PR DESCRIPTION
updated checklist component to have correct markup now wrapped in
<form> tag.
added css overrides to remove double boxes